### PR TITLE
allow co-pg client pool as connection argument to constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,17 @@ function PgSession(connection, options) {
  */
 PgSession.prototype.query = function *(sql, params) {
 
-    //Connect using the saved connection settings
-    const connectionResults = yield pg.connectPromise(this.connection);
-    const client = connectionResults[0];
-    const done = connectionResults[1];
+    let client, done;
+    if (this.connection.client && this.connection.done) {
+        //Connect using a koa-pg client pool
+        client = this.connection.client;
+        done = this.connection.done;
+    } else {
+        //or build our own by passing the connection settings to co-pg
+        const connectionResults = yield pg.connectPromise(this.connection);
+        client = connectionResults[0];
+        done = connectionResults[1];
+    }
 
     //Run the query, return the client to the pool, then return the query result
     const result = yield client.queryPromise(sql, params);


### PR DESCRIPTION
When using `koa-pg-session` in conjunction with `koa-pg`, it can be desirable to share a single `co-pg` client pool among both sessions table access and generic database queries -- in particular for small setups where the sessions table and other tables are running on the same postgres server. This PR allows a `co-pg` object to be passed in to the `PgSession` constructor:

``` JavaScript
import koa from 'koa';
const app = koa();

import koaPg from 'koa-pg';
app.use(koaPg({
    name: 'db',
    conStr: 'postgres://...'
}));

import genericSession from 'koa-generic-session';
import PgSession from 'koa-pg-session';
app.use(function * (next) {
    const session = genericSession({
        store: new PgSession(this.pg.db)
    })
    yield session.call(this, next);
});
```
