### PR TITLE
fixed: parameter sid was not properly passed to destroyValueSql causing an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ PgSession.prototype.set = function *(sid, sess, ttl) {
  * @param sid The Koa session ID of the session to destroy
  */
 PgSession.prototype.destroy = function *(sid) {
-    yield this.query(this.destroyValueSql, sid);
+    yield this.query(this.destroyValueSql, [sid]);
 };
 
 /**


### PR DESCRIPTION
The error message was: "bind message supplies 41 parameters, but prepared statement "" requires 1"
