### PR TITLE
Fixes bug: cleanup deletes all sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = class PgSession extends EventEmitter {
 
         //Each interval of cleanupTime, run the cleanup script
         setTimeout(function interval() {
-            sess.query(sess.cleanupSql, Date.now() / 1000).then(()=> {
+            sess.query(sess.cleanupSql).then(()=> {
                 //Recurse so that the cleanupTime can be dynamic
                 setTimeout(interval, sess.options.cleanupTime);
             });
@@ -211,7 +211,7 @@ module.exports = class PgSession extends EventEmitter {
      */
     get cleanupSql() {
         return escape(
-            'DELETE FROM %I.%I WHERE expiry <= to_timestamp($1);',
+            'DELETE FROM %I.%I WHERE expiry <= now();',
             this.options.schema,
             this.options.table
         );

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = class PgSession extends EventEmitter {
 
         //Each interval of cleanupTime, run the cleanup script
         setTimeout(function interval() {
-            sess.query(sess.cleanupSql, Date.now()).then(()=> {
+            sess.query(sess.cleanupSql, Date.now() / 1000).then(()=> {
                 //Recurse so that the cleanupTime can be dynamic
                 setTimeout(interval, sess.options.cleanupTime);
             });

--- a/test/test.js
+++ b/test/test.js
@@ -203,6 +203,7 @@ describe('Automatic cleanup', ()=> {
     const expiryTime = 100;
     const beforeExpiry = 50;
     const afterExpiry = 150;
+    const cleanupTime = 25;
 
     afterEach(function (done) {
         //Once we're done, delete the table
@@ -217,7 +218,7 @@ describe('Automatic cleanup', ()=> {
             //Create the session and begin cleanup
             const session = new PgSession(
                 connection,
-                Object.assign({create: true, cleanupTime: expiryTime},
+                Object.assign({create: true, cleanupTime: cleanupTime},
                     sampleTable)
             );
             yield session.setup();


### PR DESCRIPTION
I came here to fix the same bug as @dizlexik in #8 . Opening anyway (rebasing on his) as I recommend simplifying and just using Postgres' now() function.

Relevant docs:
- [Date.now()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now) outputs milliseconds.
- [to_timestamp()](http://www.postgresql.org/docs/current/static/functions-formatting.html) expects seconds.
- [now()](http://www.postgresql.org/docs/current/static/functions-datetime.html) outputs the current date and time.
